### PR TITLE
Clarify comment about restoring the SandstormApi capability.

### DIFF
--- a/server.c++
+++ b/server.c++
@@ -385,9 +385,10 @@ public:
     capnp::TwoPartyVatNetwork network(*stream, capnp::rpc::twoparty::Side::CLIENT);
     auto rpcSystem = capnp::makeRpcServer(network, kj::heap<UiViewImpl>());
 
-    // Get the SandstormApi default capability from the supervisor.
-    // TODO(soon):  We don't use this, but for some reason the connection doesn't come up if we
-    //   don't do this restore.  Cap'n Proto bug?  v8capnp bug?  Shell bug?
+    // The `CLIENT` side of a `capnp::TwoPartyVatNetwork` does not serve its bootstrap capability
+    // until it has initiated a request for the bootstrap capability of the `SERVER` side.
+    // Therefore, we need to restore the supervisor's `SandstormApi` capability, even if we are not
+    // going to use it.
     {
       capnp::MallocMessageBuilder message;
       auto vatId = message.getRoot<capnp::rpc::twoparty::VatId>();


### PR DESCRIPTION
See: https://github.com/sandstorm-io/capnproto/blob/96635cc8255f29a7ac26556744e58a4c24cc47c8/c%2B%2B/src/capnp/rpc-twoparty.c%2B%2B#L65-L70 and https://github.com/sandstorm-io/capnproto/blob/96635cc8255f29a7ac26556744e58a4c24cc47c8/c%2B%2B/src/capnp/rpc.c%2B%2B#L2649
