### PR TITLE
remove no-longer-needed workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ SANDSTORM_CAPNP_DIR=/opt/sandstorm/latest/usr/include
 
 .PHONEY: all clean dev
 
-package.spk: server sandstorm-pkgdef.capnp empty
+package.spk: server sandstorm-pkgdef.capnp
 	spk pack package.spk
 
-dev: server sandstorm-pkgdef.capnp empty
+dev: server sandstorm-pkgdef.capnp
 	spk dev
 
 clean:
-	rm -rf tmp server package.spk empty
+	rm -rf tmp server package.spk
 
 tmp/genfiles:
 	@mkdir -p tmp
@@ -21,7 +21,3 @@ tmp/genfiles:
 
 server: tmp/genfiles server.c++
 	$(CXX) -static server.c++ tmp/sandstorm/*.capnp.c++ -o server $(CXXFLAGS2) `pkg-config capnp-rpc --cflags --libs`
-
-empty:
-	mkdir -p empty
-

--- a/sandstorm-pkgdef.capnp
+++ b/sandstorm-pkgdef.capnp
@@ -50,12 +50,9 @@ const pkgdef :Spk.PackageDefinition = (
     searchPath = [
       ( packagePath = "server", sourcePath = "server" ),
       # Map server binary at "/server".
-      
+
       ( packagePath = "client", sourcePath = "client" ),
       # Map client directory at "/client".
-
-      ( sourcePath = "empty" )
-      # Make sure / is mapped to work around Sandstorm bug (temporary).
     ]
   ),
 


### PR DESCRIPTION
Depends on https://github.com/sandstorm-io/sandstorm/pull/2607.

Closes #5.
